### PR TITLE
Point Cloud Publication Support in ORBSLAM3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(orb_slam3_lib SHARED
   orb_slam3/src/LoopClosing.cc
   orb_slam3/src/ORBextractor.cc
   orb_slam3/src/ORBmatcher.cc
+  orb_slam3/src/OctoMapBuilder.cpp
   orb_slam3/src/FrameDrawer.cc
   orb_slam3/src/Converter.cc
   orb_slam3/src/MapPoint.cc

--- a/include/slam/monocular.hpp
+++ b/include/slam/monocular.hpp
@@ -17,6 +17,7 @@ class MonocularSlamNode : public SlamNode
 		std::string mpCameraTopicName;
 		std::string mpSlamSettingsFilePath;
 		std::string mpVocabFilePath;
+		Frame mpCurrentFrame;
 		std::unique_ptr<Slam> mpSlam = nullptr;
 		// ORB_SLAM3 related attributes
 #ifdef USE_ORBSLAM3
@@ -30,6 +31,7 @@ class MonocularSlamNode : public SlamNode
 		// Publishers, Subscribers, Services and Actions
 		rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr mpFrameSubscriber;
 		rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr mpAnnotatedFramePublisher;
+		rclcpp::Publisher<MapMsg>::SharedPtr mpMapPointPublisher;
 		rclcpp::Service<custom_interfaces::srv::StartupSlam>::SharedPtr mpSlamStartupService;
 		rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr mpSlamShutdownService;
 		// Callbacks and Methods
@@ -39,4 +41,10 @@ class MonocularSlamNode : public SlamNode
 				std::shared_ptr<custom_interfaces::srv::StartupSlam::Response> response);
 		void GrabImage(const sensor_msgs::msg::Image::SharedPtr msg);
 		void PublishFrame();
+#ifdef USE_ORBSLAM3
+		void PublishMapPointsCallback(std::vector<ORB_SLAM3::MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+		MapMsg MapPointsToPointCloud(std::vector<ORB_SLAM3::MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+		// TODO need to make this a parameter
+		int mpNumMinObsPerPoint = 2;
+#endif
 };

--- a/include/slam/node.hpp
+++ b/include/slam/node.hpp
@@ -3,6 +3,7 @@
 
 #include "slam/slam.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "std_srvs/srv/trigger.hpp"
 #include "tf2_ros/transform_broadcaster.h"
@@ -13,6 +14,7 @@
 using ImageMsg = sensor_msgs::msg::Image;
 using MarkerMsg = visualization_msgs::msg::Marker;
 using PointMsg = geometry_msgs::msg::Point;
+using MapMsg = sensor_msgs::msg::PointCloud2;
 
 bool readYAMLFile(std::string &yamlPath, YAML::Node &output);
 

--- a/include/slam/orbslam3/monocular.hpp
+++ b/include/slam/orbslam3/monocular.hpp
@@ -46,6 +46,8 @@ class MonoORBSLAM3 : public Slam{
 		};
 		void TrackMonocular(Frame &frame, Sophus::SE3f &tcw);
 		void InitialiseSlam(std::shared_ptr<custom_interfaces::srv::StartupSlam::Request> request, std::shared_ptr<custom_interfaces::srv::StartupSlam::Response> response);
+		void SetFrameMapPointUpdateCallback(std::function<void(std::vector<ORB_SLAM3::MapPoint*>&, const Sophus::SE3<float>&)> callback);
+
 	private:
 		// ORBSLAM3 Related pointers
 		std::string mpVocabFilePath = "";

--- a/include/slam/slam.hpp
+++ b/include/slam/slam.hpp
@@ -13,21 +13,31 @@
 #include <string>
 #include "rclcpp/rclcpp.hpp"
 #include <sophus/se3.hpp>
+#ifdef USE_ORBSLAM3
+#include "MapPoint.h"
+#endif
+#ifdef  USE_MORBSLAM
+#include "MORB_SLAM/MapPoint.h"
+#endif
 
 using StartupSlam = custom_interfaces::srv::StartupSlam;
 using ShutdownSlam = std_srvs::srv::Trigger;
 
 class Frame{
 	public:
+		Frame() = default;
 		Frame(std::shared_ptr<cv::Mat> image, long &timestamp);
 		cv::Mat getImage(){
 			return *(mpImage.get());
 		}
-		long getTimestampMSec(){
+		double getTimestampMSec(){
 			return mpTimestamp * 1e-6;
 		}
-		long getTimestampSec(){
+		double getTimestampSec(){
 			return mpTimestamp * 1e-9;
+		}
+		long getTimestampNSec(){
+			return mpTimestamp;
 		}
 		Sophus::SE3f getTransform(){
 			return Tcw;
@@ -55,6 +65,9 @@ class Slam{
 		virtual void Shutdown() = 0;
 		virtual cv::Mat GetCurrentFrame() = 0;
 		virtual void TrackMonocular(Frame &frame, Sophus::SE3f &tcw) = 0;
+#ifdef USE_ORBSLAM3
+		virtual void SetFrameMapPointUpdateCallback(std::function<void(std::vector<ORB_SLAM3::MapPoint*>&, const Sophus::SE3<float>&)> callback) = 0;
+#endif
 		rclcpp::Logger mpLogger;
 	private:	
 		// Getter Methods

--- a/orb_slam3/include/OctoMapBuilder.h
+++ b/orb_slam3/include/OctoMapBuilder.h
@@ -1,0 +1,19 @@
+#ifndef OCTOMAPBUILDER_H
+#define OCTOMAPBUILDER_H
+#include <memory>
+#include "MapPoint.h"
+
+namespace ORB_SLAM3{
+class OctoMapBuilder{
+	public:
+		OctoMapBuilder();
+		void SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> frameUpdateCallback);
+		bool Initialise();
+		void FrameMapPointUpdateCallback(std::vector<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+		void FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+	private:
+		System* mpSystem;
+		std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> mpFrameMapPointUpdateCallback;
+};
+}
+#endif

--- a/orb_slam3/include/System.h
+++ b/orb_slam3/include/System.h
@@ -39,6 +39,7 @@
 #include "Viewer.h"
 #include "ImuTypes.h"
 #include "Settings.h"
+#include "OctoMapBuilder.h"
 
 
 namespace ORB_SLAM3
@@ -237,6 +238,10 @@ private:
     // a pose graph optimization and full bundle adjustment (in a new thread) afterwards.
     LoopClosing* mpLoopCloser;
 
+	// OctoMapBuilder to update octomap object for planning
+	// Current function of the class is to serve as a communication interface for ROS2
+	OctoMapBuilder* mpOctoMapBuilder;
+
     // The viewer draws the map and the current camera pose. It uses Pangolin.
     Viewer* mpViewer;
 
@@ -276,6 +281,12 @@ private:
     string mStrVocabularyFilePath;
 
     Settings* settings_;
+
+public:
+	void FrameMapPointUpdateCallback(std::vector<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+	void FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+	void SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> frameUpdateCallback);
+
 };
 
 }// namespace ORB_SLAM

--- a/orb_slam3/src/OctoMapBuilder.cpp
+++ b/orb_slam3/src/OctoMapBuilder.cpp
@@ -1,0 +1,20 @@
+#include "OctoMapBuilder.h"
+
+namespace ORB_SLAM3{
+OctoMapBuilder::OctoMapBuilder(){
+	std::cout<<"Creating OctoMapBuilder Interface"<<std::endl;
+}
+
+void OctoMapBuilder::SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> frameUpdateCallback){
+	mpFrameMapPointUpdateCallback = frameUpdateCallback;
+}
+
+void OctoMapBuilder::FrameMapPointUpdateCallback(std::vector<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw){
+	mpFrameMapPointUpdateCallback(mapPoints, tcw);
+}
+
+void OctoMapBuilder::FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw){
+	std::vector<MapPoint*> vMapPoints(mapPoints.begin(), mapPoints.end());
+	mpFrameMapPointUpdateCallback(vMapPoints, tcw);
+}
+}

--- a/orb_slam3/src/System.cc
+++ b/orb_slam3/src/System.cc
@@ -193,6 +193,8 @@ System::System(const string &strVocFile, const string &strSettingsFile, const eS
     // mSensor!=MONOCULAR && mSensor!=IMU_MONOCULAR
     mpLoopCloser = new LoopClosing(mpAtlas, mpKeyFrameDatabase, mpVocabulary, mSensor!=MONOCULAR, activeLC); // mSensor!=MONOCULAR);
     mptLoopClosing = new thread(&ORB_SLAM3::LoopClosing::Run, mpLoopCloser);
+	
+	mpOctoMapBuilder = new OctoMapBuilder();
 
     //Set pointers between threads
     mpTracker->SetLocalMapper(mpLocalMapper);
@@ -375,6 +377,7 @@ Sophus::SE3f System::TrackRGBD(const cv::Mat &im, const cv::Mat &depthmap, const
     mTrackedMapPoints = mpTracker->mCurrentFrame.mvpMapPoints;
     mTrackedKeyPointsUn = mpTracker->mCurrentFrame.mvKeysUn;
     mTrackedKeyPoints = mpTracker->mCurrentFrame.mvKeys;
+	FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
 
     return Tcw;
 }
@@ -1621,6 +1624,18 @@ bool System::SaveMap(const string &filename)
         return SaveAtlas(FileType::BINARY_FILE);
     }
     return false;
+}
+
+void System::FrameMapPointUpdateCallback(std::vector<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw){
+	mpOctoMapBuilder->FrameMapPointUpdateCallback(mapPoints, tcw);
+}
+
+void System::FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw){
+	mpOctoMapBuilder->FrameMapPointUpdateCallback(mapPoints, tcw);
+}
+
+void System::SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> frameUpdateCallback){
+	mpOctoMapBuilder->SetFrameMapPointUpdateCallback(frameUpdateCallback);
 }
 
 } //namespace ORB_SLAM

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -30,7 +30,7 @@ void SlamNode::PublishPositionAsTransform(Sophus::SE3f &tcw){
 	// Get transform from slam to camera frame as a message
 	geometry_msgs::msg::TransformStamped msg;
 	msg.header.stamp = this->get_clock()->now();
-	msg.header.frame_id = "slam";
+	msg.header.frame_id = "map";
 	msg.child_frame_id = "camera";
 	msg.transform  = sophusToTransformMsg(tcw); 
 	// Broadcast tf                                                       

--- a/src/orbslam3/monocular.cpp
+++ b/src/orbslam3/monocular.cpp
@@ -57,3 +57,7 @@ void MonoORBSLAM3::TrackMonocular(Frame &frame, Sophus::SE3f &tcw){
 	tcw = mpORBSlam3->TrackMonocular(frame.getImage(), frame.getTimestampSec());
 }
 
+
+void MonoORBSLAM3::SetFrameMapPointUpdateCallback(std::function<void(std::vector<ORB_SLAM3::MapPoint*>&, const Sophus::SE3<float>&)> callback){
+	mpORBSlam3->SetFrameMapPointUpdateCallback(callback);
+}


### PR DESCRIPTION
Problem
======
1. Need to publish map points from within ORB_SLAM3 for planning
2. MapPoint Publication must reflect updates from Tracking, Local Mapping and Loop Closure respectively

Solution
======
1. Added `PublishMapPointsCallback(...)` in `include/slam/monocular.hpp` and `src/monocular.cpp` to provide the callback to ORB_SLAM3
2. Implemented `MapPointsToPointCloud(...)` to convert `std::vector<ORB_SLAM3::MapPoint*>` to `sensor_msgs::msg::PointCloud2`
3. Added `SetFrameMapPointUpdateCallback(...)` in  `include/slam/monocular.hpp` and `src/monocular.cpp` to provide the callback to ORB_SLAM3
4. Resolved all dependency issues within the package to ensure successful build
5. Added `mpCurrentFrame` attribute to store all current frame related information in `include/slam/moncular.hpp`
6. Added `mpMapPointPublisher` in `include/slam/monocular.hpp` and `src/monocular.cpp` to publish `sensor_msgs::msg::PointCloud2` messages
7. Implemented the OctoMapBuilder interface to collect map points for any updated frame or keyframe
8. Implemented callback `FrameMapPointUpdateCallback` in `*/System.*` and `*/OctoMapBuilder.*` for callback execution
9. Added API in `*/System.*` to set callback for `mpOctoMapBuilder`

Note
====
1. Build Successful
2. ORB_SLAM3 functions with Tello data stream
3. Unable to publish map point data
4. To be tested with video publisher node