### PR TITLE
PointCloud3 publication from ORB_SLAM3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(Yaml-cpp REQUIRED)
 find_package(MORB_SLAM REQUIRED COMPONENTS MORB_SLAM DBoW2 g2o sophus)
 find_package(octomap REQUIRED)
+find_package(octomap_ros REQUIRED)
+find_package(octomap_msgs REQUIRED)
 
 # Header file locations [C++ node]
 include_directories(

--- a/include/slam/monocular.hpp
+++ b/include/slam/monocular.hpp
@@ -19,6 +19,7 @@ class MonocularSlamNode : public SlamNode
 		std::string mpVocabFilePath;
 		Frame mpCurrentFrame;
 		std::unique_ptr<Slam> mpSlam = nullptr;
+		Eigen::Matrix3d mpOrbToROSTransform;
 		// ORB_SLAM3 related attributes
 #ifdef USE_ORBSLAM3
 		ORB_SLAM3::Tracking::eTrackingState mpState;
@@ -43,7 +44,8 @@ class MonocularSlamNode : public SlamNode
 		void PublishFrame();
 #ifdef USE_ORBSLAM3
 		void PublishMapPointsCallback(std::vector<ORB_SLAM3::MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
-		MapMsg MapPointsToPointCloud(std::vector<ORB_SLAM3::MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+		void MapPointsToPointCloud(std::vector<ORB_SLAM3::MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw, sensor_msgs::msg::PointCloud2 &cloud);
+		void SophusToGeometryMsgTransform(const Sophus::SE3<float>& se3, geometry_msgs::msg::Transform &pose);
 		// TODO need to make this a parameter
 		int mpNumMinObsPerPoint = 2;
 #endif

--- a/include/slam/node.hpp
+++ b/include/slam/node.hpp
@@ -10,11 +10,12 @@
 #include "tf2/LinearMath/Transform.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include "custom_interfaces/msg/point_cloud3.hpp"
 
 using ImageMsg = sensor_msgs::msg::Image;
 using MarkerMsg = visualization_msgs::msg::Marker;
 using PointMsg = geometry_msgs::msg::Point;
-using MapMsg = sensor_msgs::msg::PointCloud2;
+using MapMsg = custom_interfaces::msg::PointCloud3;
 
 bool readYAMLFile(std::string &yamlPath, YAML::Node &output);
 

--- a/orb_slam3/config/Monocular/tello.yaml
+++ b/orb_slam3/config/Monocular/tello.yaml
@@ -33,7 +33,7 @@ Camera.RGB: 1
 # ORB Parameters
 #--------------------------------------------------------------------------------------------
 # ORB Extractor: Number of features per image
-ORBextractor.nFeatures: 1250
+ORBextractor.nFeatures: 3600
 
 # ORB Extractor: Scale factor between levels in the scale pyramid 	
 ORBextractor.scaleFactor: 1.2

--- a/orb_slam3/src/System.cc
+++ b/orb_slam3/src/System.cc
@@ -305,7 +305,7 @@ Sophus::SE3f System::TrackStereo(const cv::Mat &imLeft, const cv::Mat &imRight, 
     mTrackedKeyPointsUn = mpTracker->mCurrentFrame.mvKeysUn;
     mTrackedKeyPoints = mpTracker->mCurrentFrame.mvKeys;
 	// std::cout<<"Tracking Pushing " << mTrackedMapPoints.size() << " map points" << std::endl;
-	FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
+	// FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
 
     return Tcw;
 }
@@ -380,7 +380,7 @@ Sophus::SE3f System::TrackRGBD(const cv::Mat &im, const cv::Mat &depthmap, const
     mTrackedKeyPointsUn = mpTracker->mCurrentFrame.mvKeysUn;
     mTrackedKeyPoints = mpTracker->mCurrentFrame.mvKeys;
 	// std::cout<<"Pushing "<<mTrackedMapPoints.size() << " map points"<<std::endl;
-	FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
+	// FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
 
     return Tcw;
 }
@@ -467,7 +467,7 @@ Sophus::SE3f System::TrackMonocular(const cv::Mat &im, const double &timestamp, 
     mTrackedKeyPointsUn = mpTracker->mCurrentFrame.mvKeysUn;
     mTrackedKeyPoints = mpTracker->mCurrentFrame.mvKeys;
 	// std::cout<<"Pushing "<<mTrackedMapPoints.size() << " map points"<<std::endl;
-	FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
+	// FrameMapPointUpdateCallback(mTrackedMapPoints, Tcw);
 
     return Tcw;
 }

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,9 @@
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>python3-natsort</build_depend>
+  <build_depend>octomap</build_depend>
+  <build_depend>octomap_ros</build_depend>
+  <build_depend>octomap_msgs</build_depend>
 
   <!-- As suggested by the official tutorial, add your custom message interfaces as follows -->
   <depend>custom_interfaces</depend>
@@ -48,6 +51,9 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>python3-natsort</exec_depend>
+  <exec_depend>octomap</exec_depend>
+  <exec_depend>octomap_ros</exec_depend>
+  <exec_depend>octomap_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/monocular.cpp
+++ b/src/monocular.cpp
@@ -11,9 +11,7 @@ MonocularSlamNode::MonocularSlamNode() : SlamNode("orbslam3_mono_node"){
 	RCLCPP_INFO(this->get_logger(), "Created SLAM Object for MORBSLAM in Mono Slam Node");
 #endif
 	mpSlamStartupService = this->create_service<StartupSlam>("~/start_slam", std::bind(&MonocularSlamNode::InitialiseSlamNode, this, std::placeholders::_1, std::placeholders::_2));
-	const double data[] = {1, 0, 0, 0, 0, -1, 0, 1, 0};
-	Eigen::Matrix3d orbToROSTransform(data);
-	mpOrbToROSTransform = orbToROSTransform;
+	mpOrbToROSTransform <<  1, 0, 0, 0, 0, -1, 0, 1, 0;
 	mpTfBroadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(tf2_ros::TransformBroadcaster(this)); 
 }
 

--- a/src/orbslam3/monocular.cpp
+++ b/src/orbslam3/monocular.cpp
@@ -49,7 +49,7 @@ void MonoORBSLAM3::InitialiseSlam(
 			response->success = false;
 			response->message = "Received unsupported camera type";
 		}
-		mpORBSlam3 = std::make_unique<ORB_SLAM3::System>(vocabFilePath, settingsFilePath, cameraType);
+		mpORBSlam3 = std::make_unique<ORB_SLAM3::System>(vocabFilePath, settingsFilePath, cameraType, false);
 	}
 }
 


### PR DESCRIPTION
Problem
=======
1. OctoMap needs sensor origin position in global map reference to build octomap from point clouds
2. Not sufficient matches detect to build a sufficiently dense map for planning effectively
3. Point clouds from tracking thread not needed for octomap building

Solution
========
1. Added octomap dependencies in CMakeLists.txt and package.xml
2. Added custom_interfaces::msg::PointCloud3 dependencies in CMakeLists.txt and package.xml
3. Updated all point cloud publication related method definitions to use custom_interfaces::msg::PointCloud3
4. Increased the number of features from 1250 to 3600 in tello.yaml
5. Removed all instances of `FrameMapPointUpdateCallback(mTrackedPoints, tcw)` from System.cc
6. Implemented ORB_SLAM3 to ROS coordinate system transformation for camera position

Note
====
1. Added `SophusToGeometryMsgTransform(...)` in MonocularSlamNode. The method may be used in other nodes as well
2. Point Clouds are only published when the local mapping thread updates the global map, thus ensuring cosistency between the octomap and ORB_SLAM3 map