### PR TITLE
ORB_SLAM3 Global Map Points and Key Frame Poses Callback

### DIFF
--- a/orb_slam3/include/LoopClosing.h
+++ b/orb_slam3/include/LoopClosing.h
@@ -118,6 +118,9 @@ public:
 
 protected:
 
+    
+    System *mpSystem;
+
     bool CheckNewKeyFrames();
 
 

--- a/orb_slam3/include/OctoMapBuilder.h
+++ b/orb_slam3/include/OctoMapBuilder.h
@@ -8,12 +8,15 @@ class OctoMapBuilder{
 	public:
 		OctoMapBuilder();
 		void SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> frameUpdateCallback);
+		void SetGlobalMPAndKFPosesCallback(std::function<void(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>>)> globalMPAndKFPosesCallback);
 		bool Initialise();
 		void FrameMapPointUpdateCallback(std::vector<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
 		void FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
+		void GlobalMPAndKFPosesCallback(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>> &globalMPAndKFPoses);
 	private:
 		System* mpSystem;
 		std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> mpFrameMapPointUpdateCallback;
+		std::function<void(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>>)> mpGlobalMPAndKFPosesCallback;
 };
 }
 #endif

--- a/orb_slam3/include/System.h
+++ b/orb_slam3/include/System.h
@@ -287,6 +287,8 @@ public:
 	void FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints, const Sophus::SE3<float> &tcw);
 	void SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPoint*>&, const Sophus::SE3<float>&)> frameUpdateCallback);
 
+    void GlobalMPAndKFPosesCallback(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>> &globalMPAndKFPoses);
+    void SetGlobalMPAndKFPosesCallback(std::function<void(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>>)> globalMPAndKFPosesCallback);
 };
 
 }// namespace ORB_SLAM

--- a/orb_slam3/src/LoopClosing.cc
+++ b/orb_slam3/src/LoopClosing.cc
@@ -2485,6 +2485,20 @@ void LoopClosing::RunGlobalBundleAdjustment(Map* pActiveMap, unsigned long nLoop
                 }
             }
 
+            const vector<KeyFrame*> vpKFs =  pActiveMap->GetAllKeyFrames();
+
+            std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>> GlobalMPAndKFPoses;
+
+            for(std::vector<KeyFrame*>::const_iterator kf_it = vpKFs.begin();kf_it< vpKFs.end();kf_it++){
+
+                std::set<MapPoint*> SetMapPoints = (*kf_it)->GetMapPoints();
+                std::vector<MapPoint*> GlobalMapPoints(SetMapPoints.begin(), SetMapPoints.end());
+                std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&> MapPointAndKFPose(GlobalMapPoints,(*kf_it)->GetPose());
+                GlobalMPAndKFPoses.push_back(MapPointAndKFPose);
+            }
+
+            mpSystem->GlobalMPAndKFPosesCallback(GlobalMPAndKFPoses);
+
             pActiveMap->InformNewBigChange();
             pActiveMap->IncreaseChangeIndex();
 

--- a/orb_slam3/src/OctoMapBuilder.cpp
+++ b/orb_slam3/src/OctoMapBuilder.cpp
@@ -17,4 +17,14 @@ void OctoMapBuilder::FrameMapPointUpdateCallback(std::set<MapPoint*> &mapPoints,
 	std::vector<MapPoint*> vMapPoints(mapPoints.begin(), mapPoints.end());
 	mpFrameMapPointUpdateCallback(vMapPoints, tcw);
 }
+
+void OctoMapBuilder::SetGlobalMPAndKFPosesCallback(std::function<void(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>>)> globalMPAndKFPosesCallback){
+	mpGlobalMPAndKFPosesCallback = globalMPAndKFPosesCallback;
+}
+
+void OctoMapBuilder::GlobalMPAndKFPosesCallback(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>> &globalMPAndKFPoses){
+	mpGlobalMPAndKFPosesCallback(globalMPAndKFPoses);
+}
+
+
 }

--- a/orb_slam3/src/System.cc
+++ b/orb_slam3/src/System.cc
@@ -1638,5 +1638,13 @@ void System::SetFrameMapPointUpdateCallback(std::function<void(std::vector<MapPo
 	mpOctoMapBuilder->SetFrameMapPointUpdateCallback(frameUpdateCallback);
 }
 
+void System::GlobalMPAndKFPosesCallback(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>> &globalMPAndKFPoses){
+	mpOctoMapBuilder->GlobalMPAndKFPosesCallback(globalMPAndKFPoses);
+}
+
+void System::SetGlobalMPAndKFPosesCallback(std::function<void(std::vector<std::pair<std::vector<MapPoint*>&, const Sophus::SE3<float>&>>)> globalMapPointCallback){
+    mpOctoMapBuilder->SetGlobalMPAndKFPosesCallback(globalMapPointCallback);
+}
+
 } //namespace ORB_SLAM
 


### PR DESCRIPTION
Problem
=======
1. Needs to Collect Global Map Points and Keyframe Poses for octomap builder
2. Map Point and keyframes reflect updates from GLobal Bundle Adjusment

Solution
========
1. Implemented a loop to iterate through each keyframes to extract Map Points and Key frame poses that stored in vector of pairs as could be seen in `LoopClosing.cc` line 2488 - 2500
2. Added `GlobalMPAndKFPosesCallback(...)` in `OctoMapBuilder.cpp`,`OctoMapBuilder.h`,`System.cc`, and `System.h` to provide GBA callback interface
3. Added `SetGlobalMPAndKFPosesCallback(...)` in `OCtoMapBuilder.cpp, `OctoMapBuilder.h`, `System.cc`, and `System.h` to provide callback interface for GBA
4. Added mpSystem attribut in `LoopClosing.h` to provide Loop Closing access to system attribute

Note
====
Build successful, need to test with Global Map point subscriber